### PR TITLE
Only show problematic module names in debug mode

### DIFF
--- a/includes/resourceloader/ResourceLoader.php
+++ b/includes/resourceloader/ResourceLoader.php
@@ -1046,8 +1046,12 @@ MESSAGE;
 			}
 		} else {
 			if ( count( $states ) ) {
-				$this->errors[] = 'Problematic modules: ' .
-					FormatJson::encode( $states, ResourceLoader::inDebugMode() );
+				if ( $context->getDebug() ) {
+					$this->errors[] = 'Problematic modules: ' .
+						FormatJson::encode( $states, ResourceLoader::inDebugMode() );
+				} else {
+					$this->errors[] = 'Could not load specified modules.';
+				}
 			}
 		}
 


### PR DESCRIPTION
WhiteHat reported vulnerability for content spoofing.  Example: /load.php?debug=false&lang=en&modules=you+should+call+someone&only=styles&skin=monobook&*